### PR TITLE
Remove space from passthrough

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -4,7 +4,7 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy('src/scripts');
   eleventyConfig.addPassthroughCopy('src/site.webmanifest');
   eleventyConfig.addPassthroughCopy('src/icon.png');
-  eleventyConfig.addPassthroughCopy('src /icon.svg');
+  eleventyConfig.addPassthroughCopy('src/icon.svg');
   eleventyConfig.addPassthroughCopy('src/favicon.ico');
 
   return {


### PR DESCRIPTION
# Bug - icon.svg 404

## Description

Fixed a passthroughCopy for an icon file, so it is available when the app is served.

[[link to ticket on issue board](https://github.com/nditcommunity/nditcommunity.github.io/issues/66)]

## Type of change

- [X] Bug fix

## Change log

- removed rogue space from passthroughCopy in eleventy config file

## Testing

- How did you test this?
Ran locally (npm run dev) and loaded the page: no more 404 for icon.svg :tada: 

## Checklist

- [X] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [X] My changes generate no new console warnings.
- [X] I manually tested to prove my fix is effective or that my feature works.
- [ ] I have assigned this PR to an [owner](https://github.com/nditcommunity/ndit-website).
