### PR TITLE
Add target="_blank" to Join our Slack anchor

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -8,5 +8,6 @@ description: online community that unites neurodivergent folks in the tech indus
 <a
   class="join-btn"
   href="http://bit.ly/nd-in-tech"
+  target="_blank"
   >Join Our Slack</a
 >


### PR DESCRIPTION
# Open "Join The Slack" link in new tab

## Description

Currently the main CTA on the home page replaces the NDIT page. This change opens the join page in a new tab.

[[link to ticket on issue board](https://github.com/nditcommunity/nditcommunity.github.io/issues/71)]

## Type of change

New feature (maybe? Meh)

## Change log

- added target="_blank" to the link.

## Testing

Tried it out manually - we get a new tab.

## Checklist

- [X] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [X] My changes generate no new console warnings.
- [X] I manually tested to prove my fix is effective or that my feature works.
- [ ] I have assigned this PR to an [owner](https://github.com/nditcommunity/ndit-website).
