### PR TITLE
PoC light/dark mode toggle using Google Fonts material-symbols

### DIFF
--- a/src/_includes/head.liquid
+++ b/src/_includes/head.liquid
@@ -72,6 +72,10 @@
     rel='apple-touch-icon'
     href='/icon.png'
   >
+  <link
+    href='https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined'
+    rel='stylesheet'
+  >
 
   <link
     rel='manifest'

--- a/src/_includes/header.liquid
+++ b/src/_includes/header.liquid
@@ -26,8 +26,8 @@
       </li>
       <li>
         <p class='nav-item theme-icon'>
-          <span class='sun-icon hidden'>☼</span>
-          <span class='moon-icon'>☾</span>
+          <span class='sun-icon hidden material-symbols-outlined'>light_mode</span>
+          <span class='moon-icon material-symbols-outlined'>dark_mode</span>
         </p>
       </li>
     </ul>

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -441,19 +441,11 @@ body.day-mode .nav-item {
   color: var(--black);
 }
 
-.theme-icon {
-  font-size: 1.2rem;
-  cursor: pointer;
-  width: 0.2rem;
-  margin-right: 16px;
-}
-
-.sun-icon {
-  color: var(--white);
-}
-
+.sun-icon,
 .moon-icon {
-  color: var(--black);
+  cursor: pointer;
+  font-size: 100% !important;
+  padding-top: 2.5px;
 }
 
 /* ---------- FOOTER ---------- */


### PR DESCRIPTION
# Sun icon misaligned on mobile

## Description

Updates the light/dark mode icons.
One of a few options we have for resolving the unfortunately different-sized icons (evident on Android).
This approach adds an additional resource to load (another Google Font) and uses that to display consistent icons.

Not attached to this approach if another one is preferred!

[Issue Board Ticket](https://github.com/nditcommunity/nditcommunity.github.io/issues/83)

Note: we can adjust the <link> request to get slight variation in style if wanted. We might need to cater specially for older browsers though (see [docs](https://developers.google.com/fonts/docs/material_symbols))

## Type of change

- [X] Bug fix
- [X] New feature

## Change log

- added Material Symbols stylesheet (via link tag)
- updated relevant spans to replace the toggle unicode with icons

## Testing

Tested on Linux which I _think_ hit the same problem as Android. Haven't tested on a real mobile device.

## Checklist

- [X] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [X] My changes generate no new console warnings.
- [X] I manually tested to prove my fix is effective or that my feature works.
- [ ] I have assigned this PR to an [owner](https://github.com/nditcommunity/ndit-website).
